### PR TITLE
Adding Table header column name for the Event Panel in DevTools porti…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "boomerang-inspector",
-    "version": "0.6.0",
+    "version": "0.6.3",
     "description": "Boomerang Inspector Browser Extension",
     "author": "Nigel Heron <nheron@querymetrics.com>",
     "license": "",

--- a/src/devtools/components/EventPanel.vue
+++ b/src/devtools/components/EventPanel.vue
@@ -2,6 +2,12 @@
     <table>
       <thead>
         <tr><td><button @click="$emit('clearEvents')">Clear Events</button></td></tr>
+        <tr>
+          <th>TimeStamp</th>
+          <th>Type</th>
+          <th>Stack</th>
+          <th>Component</th>
+        </tr>
       </thead>
       <tfoot>
         <tr><td><button @click="$emit('clearEvents')">Clear Events</button></td></tr>
@@ -36,6 +42,7 @@
     th {
     background: #F3F3F3;
     font-weight: bold;
+    text-align: left;
     }
     td {
     border: 1px solid #eee;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -40,5 +40,14 @@
     "options_ui": {
         "page":"options/options.html"
     },
+    "commands": {
+        "_execute_browser_action": {
+          "suggested_key": {
+            "default": "Ctrl+Shift+B",
+            "mac": "MacCtrl+Shift+B"
+          },
+          "description": "Opens Boomerang Inspector"
+        }
+    },
     "manifest_version": 2
 }


### PR DESCRIPTION
…on. Also adding shortcut to open Boomerang plugin

EventPanel in DevTools right now shows tables in table structure but looks to be missing the table headers making it a bit harder, at first glance, to understand what data is being shown in the table. Adding header columns descriptions to the table in the Event panel.
![Screen Shot 2021-01-12 at 11 42 29 AM](https://user-images.githubusercontent.com/7560195/104383329-81aff080-54e4-11eb-92d1-8d21ca7db9d1.jpg)


Also taking the opportunity to add a keyboard shortcut to invoke the Boomerang inspector plugin via CNTRL+Shift+B